### PR TITLE
Update employer_contributor_license_agreement.md

### DIFF
--- a/employer_contributor_license_agreement.md
+++ b/employer_contributor_license_agreement.md
@@ -64,4 +64,4 @@ I agree with all the terms and conditions above by providing my details in **tab
 | Name (“You”) | Github ID | Employer | Country | Date |
 | --- | --- | --- | --- | --- |
 | `Mathew Dennis` | [mathewdennis1](https://github.com/mathewdennis1) | Core.ai Scientific Technologies Private Ltd. |India |14-June-2021|
-| `Phoenix Code Bot` | [Phoenix Code Bot](https://github.com/phoenixide) | Excemted ci tool account. |India |26-may-2021|
+| `Core.ai bot` | [Core.ai bot](https://github.com/core-ai-bot) | Excemted ci tool account. |India |26-may-2021|


### PR DESCRIPTION
adding ci/cd bot account exemption for: `Core.ai bot`